### PR TITLE
Add ostruct gem dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ gem 'rubocop'
 gem 'rswag'
 
 gem 'kramdown'
+gem 'ostruct'
 gem 'rake'
 gem 'rspec'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,6 +162,7 @@ GEM
     nokogiri (1.18.10-x86_64-linux-gnu)
       racc (~> 1.4)
     orm_adapter (0.5.0)
+    ostruct (0.6.3)
     parallel (1.27.0)
     parser (3.3.9.0)
       ast (~> 2.4.1)
@@ -318,6 +319,7 @@ DEPENDENCIES
   figaro
   jwt
   kramdown
+  ostruct
   pg (~> 1.1)
   puma (~> 6.0)
   rack-cors


### PR DESCRIPTION
## Summary
- Added `ostruct` gem to Gemfile as an explicit dependency

## Why This Change Is Needed
OpenStruct will be removed from the Ruby standard library starting with Ruby 3.5. By adding it as an explicit gem dependency now, we ensure the application will continue to work seamlessly when upgrading to future Ruby versions.

## Changes
- Added `gem 'ostruct'` to Gemfile
- Ran `bundle install` to update Gemfile.lock

## Test Plan
- [x] Bundle install completes successfully
- [x] Application starts without errors with Rails 8 and Ruby 3.4.5
- [ ] All tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)